### PR TITLE
Adding build script and remove deprecated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ build:
 # Get all dependencies
 get-deps:
 	# Go tools
-	go get golang.org/x/tools/cmd/vet
 	go get github.com/golang/lint/golint
 
 	# Test tools

--- a/README.md
+++ b/README.md
@@ -74,23 +74,11 @@ a new version of that file.
 
 ## Example Configuration
 
-### Enabling this resource on your Concourse workers
-
-In your bosh deployment manifest, add the `additional_resource_types` property to the `groundcrew` job:
-
-```yaml
-properties:
-  groundcrew:
-    additional_resource_types:
-      - type: gcs-resource
-        image: docker:///frodenas/gcs-resource
-```
-
 ### Resource Type
 
 ```yaml
 resource_types:
-  - name: gcs-request
+  - name: gcs-resource
     type: docker-image
     source:
       repository: frodenas/gcs-resource
@@ -128,3 +116,19 @@ First get the resource via: `go get github.com/frodenas/gcs-resource`
 Run the `unit-tests`: `make`
 
 Run the `integration-tests`: `make integration-tests`
+
+## Developing using Concourse
+Clone this repository and just run one-off task with concourse
+
+```bash
+fly -t ConcourseTarget execute -c build.yml -i gcs-resource=. -o built-resource=.
+```
+
+
+Just build the Docker image to be use inside your pipeline
+
+```bash
+ docker build -t frodenas/gcs-resource .
+```
+
+

--- a/build.yml
+++ b/build.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: concourse/static-golang
+
+
+inputs:
+- name: gcs-resource
+  path: gopath/src/github.com/frodenas/gcs-resource
+
+outputs:
+- name: built-resource
+
+run:
+  path: gopath/src/github.com/frodenas/gcs-resource/scripts/ci

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,17 @@
+#!/bin/bash
+# vim: set ft=sh
+
+set -e -x
+
+ROOT=$PWD
+
+export GOPATH=$PWD/gopath
+export PATH=$GOPATH/bin:$PATH
+
+BUILD_DIR=$PWD/built-resource
+
+cd $GOPATH/src/github.com/frodenas/gcs-resource
+
+make
+
+cp -a assets/ Dockerfile $BUILD_DIR


### PR DESCRIPTION
## Added

Nifty script to build / test etc ... the asset using ConcourseCI

``` bash
fly -t ConcourseTarget execute -c build.yml -i gcs-resource=. -o built-resource=.
```
## Depracated  / Removed

additional_resource_types is now deprecated using docker  image
