### PR TITLE
Fix error when putting to versioned bucket

### DIFF
--- a/check/check_command.go
+++ b/check/check_command.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/frodenas/gcs-resource"
 	"github.com/frodenas/gcs-resource/versions"
@@ -56,11 +57,16 @@ func (command *CheckCommand) checkByVersionedFile(request CheckRequest) (CheckRe
 		return response, nil
 	}
 
-	if request.Version.Generation != 0 {
+	if request.Version.Generation != "" {
 		for _, generation := range generations {
-			if generation > request.Version.Generation {
+			requestGeneration, err := request.Version.GenerationValue()
+			if err != nil {
+				return nil, err
+			}
+
+			if generation > requestGeneration {
 				version := gcsresource.Version{
-					Generation: generation,
+					Generation: fmt.Sprintf("%d", generation),
 				}
 				response = append(response, version)
 			}
@@ -74,7 +80,7 @@ func (command *CheckCommand) checkByVersionedFile(request CheckRequest) (CheckRe
 		}
 
 		version := gcsresource.Version{
-			Generation: maxGeneration,
+			Generation: fmt.Sprintf("%d", maxGeneration),
 		}
 		response = append(response, version)
 	}

--- a/check/check_command_test.go
+++ b/check/check_command_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Check Command", func() {
 					Expect(response).To(HaveLen(1))
 					Expect(response).To(ConsistOf(
 						gcsresource.Version{
-							Generation: 1234,
+							Generation: "1234",
 						},
 					))
 				})
@@ -186,7 +186,7 @@ var _ = Describe("Check Command", func() {
 
 			Context("when there is a previous version", func() {
 				BeforeEach(func() {
-					request.Version.Generation = 456
+					request.Version.Generation = "456"
 				})
 
 				It("includes the most recent versions", func() {
@@ -196,10 +196,10 @@ var _ = Describe("Check Command", func() {
 					Expect(response).To(HaveLen(2))
 					Expect(response).To(ConsistOf(
 						gcsresource.Version{
-							Generation: 789,
+							Generation: "789",
 						},
 						gcsresource.Version{
-							Generation: 1234,
+							Generation: "1234",
 						},
 					))
 				})
@@ -207,7 +207,7 @@ var _ = Describe("Check Command", func() {
 				Context("and the version does not exists", func() {
 					Context("but there are greater versions", func() {
 						BeforeEach(func() {
-							request.Version.Generation = 1000
+							request.Version.Generation = "1000"
 						})
 
 						It("returns the latest version", func() {
@@ -217,7 +217,7 @@ var _ = Describe("Check Command", func() {
 							Expect(response).To(HaveLen(1))
 							Expect(response).To(ConsistOf(
 								gcsresource.Version{
-									Generation: 1234,
+									Generation: "1234",
 								},
 							))
 						})
@@ -225,7 +225,7 @@ var _ = Describe("Check Command", func() {
 
 					Context("and there are not greater versions", func() {
 						BeforeEach(func() {
-							request.Version.Generation = 9999
+							request.Version.Generation = "9999"
 						})
 
 						It("returns the latest version", func() {

--- a/gcsclient.go
+++ b/gcsclient.go
@@ -23,7 +23,7 @@ type GCSClient interface {
 }
 
 type gcsclient struct {
-	storageService  *storage.Service
+	storageService *storage.Service
 	progressOutput io.Writer
 }
 

--- a/in/in_command.go
+++ b/in/in_command.go
@@ -2,6 +2,7 @@ package in
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -97,7 +98,10 @@ func (command *InCommand) pathToDownload(request InRequest) (string, error) {
 func (command *InCommand) inByVersionedFile(destinationDir string, request InRequest) (InResponse, error) {
 	bucketName := request.Source.Bucket
 	objectPath := request.Source.VersionedFile
-	generation := request.Version.Generation
+	generation, err := request.Version.GenerationValue()
+	if err != nil {
+		return InResponse{}, err
+	}
 
 	if err := command.downloadFile(bucketName, objectPath, generation, destinationDir); err != nil {
 		return InResponse{}, err
@@ -118,7 +122,7 @@ func (command *InCommand) inByVersionedFile(destinationDir string, request InReq
 
 	return InResponse{
 		Version: gcsresource.Version{
-			Generation: generation,
+			Generation: fmt.Sprintf("%d", generation),
 		},
 		Metadata: command.metadata(objectPath, url),
 	}, nil

--- a/in/in_command_test.go
+++ b/in/in_command_test.go
@@ -179,7 +179,7 @@ var _ = Describe("In Command", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(response.Version.Path).To(Equal("folder/file-3.53.tgz"))
-					Expect(response.Version.Generation).To(Equal(int64(0)))
+					Expect(response.Version.Generation).To(Equal(""))
 
 					Expect(response.Metadata[0].Name).To(Equal("filename"))
 					Expect(response.Metadata[0].Value).To(Equal("file-3.53.tgz"))
@@ -292,7 +292,7 @@ var _ = Describe("In Command", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(response.Version.Path).To(Equal("folder/file-1.3.tgz"))
-					Expect(response.Version.Generation).To(Equal(int64(0)))
+					Expect(response.Version.Generation).To(Equal(""))
 
 					Expect(response.Metadata[0].Name).To(Equal("filename"))
 					Expect(response.Metadata[0].Value).To(Equal("file-1.3.tgz"))
@@ -322,7 +322,7 @@ var _ = Describe("In Command", func() {
 		Describe("with versioned_file", func() {
 			BeforeEach(func() {
 				request.Source.VersionedFile = "folder/version"
-				request.Version.Generation = int64(12345)
+				request.Version.Generation = "12345"
 			})
 
 			It("creates the destination directory", func() {
@@ -387,7 +387,7 @@ var _ = Describe("In Command", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(response.Version.Path).To(BeEmpty())
-				Expect(response.Version.Generation).To(Equal(int64(12345)))
+				Expect(response.Version.Generation).To(Equal("12345"))
 
 				Expect(response.Metadata[0].Name).To(Equal("filename"))
 				Expect(response.Metadata[0].Value).To(Equal("version"))

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -450,7 +451,7 @@ var _ = Describe("check", func() {
 
 					Expect(checkResponse).To(Equal(check.CheckResponse{
 						{
-							Generation: generation3,
+							Generation: fmt.Sprintf("%d", generation3),
 						},
 					}))
 				})
@@ -466,7 +467,7 @@ var _ = Describe("check", func() {
 								VersionedFile: filepath.Join(directoryPrefix, "version"),
 							},
 							Version: gcsresource.Version{
-								Generation: generation1,
+								Generation: fmt.Sprintf("%d", generation1),
 							},
 						}
 
@@ -481,10 +482,10 @@ var _ = Describe("check", func() {
 
 						Expect(checkResponse).To(Equal(check.CheckResponse{
 							{
-								Generation: generation2,
+								Generation: fmt.Sprintf("%d", generation2),
 							},
 							{
-								Generation: generation3,
+								Generation: fmt.Sprintf("%d", generation3),
 							},
 						}))
 					})
@@ -500,7 +501,7 @@ var _ = Describe("check", func() {
 									VersionedFile: filepath.Join(directoryPrefix, "version"),
 								},
 								Version: gcsresource.Version{
-									Generation: generation2 + 1,
+									Generation: fmt.Sprintf("%d", generation2+1),
 								},
 							}
 
@@ -515,7 +516,7 @@ var _ = Describe("check", func() {
 
 							Expect(checkResponse).To(Equal(check.CheckResponse{
 								{
-									Generation: generation3,
+									Generation: fmt.Sprintf("%d", generation3),
 								},
 							}))
 						})
@@ -530,7 +531,7 @@ var _ = Describe("check", func() {
 									VersionedFile: filepath.Join(directoryPrefix, "version"),
 								},
 								Version: gcsresource.Version{
-									Generation: generation3 + 1,
+									Generation: fmt.Sprintf("%d", generation3+1),
 								},
 							}
 

--- a/integration/in_test.go
+++ b/integration/in_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -363,7 +364,7 @@ var _ = Describe("in", func() {
 							VersionedFile: filepath.Join(directoryPrefix, "version"),
 						},
 						Version: gcsresource.Version{
-							Generation: generation2,
+							Generation: fmt.Sprintf("%d", generation2),
 						},
 					}
 
@@ -390,7 +391,7 @@ var _ = Describe("in", func() {
 
 					Expect(inResponse).To(Equal(in.InResponse{
 						Version: gcsresource.Version{
-							Generation: generation2,
+							Generation: fmt.Sprintf("%d", generation2),
 						},
 						Metadata: []gcsresource.MetadataPair{
 							{
@@ -430,7 +431,7 @@ var _ = Describe("in", func() {
 							VersionedFile: filepath.Join(directoryPrefix, "missing"),
 						},
 						Version: gcsresource.Version{
-							Generation: generation2,
+							Generation: fmt.Sprintf("%d", generation2),
 						},
 					}
 
@@ -456,7 +457,7 @@ var _ = Describe("in", func() {
 							VersionedFile: filepath.Join(directoryPrefix, "version"),
 						},
 						Version: gcsresource.Version{
-							Generation: int64(12345),
+							Generation: "12345",
 						},
 					}
 
@@ -480,7 +481,7 @@ var _ = Describe("in", func() {
 							VersionedFile: filepath.Join(directoryPrefix, "missing"),
 						},
 						Version: gcsresource.Version{
-							Generation: 0,
+							Generation: "0",
 						},
 					}
 

--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -365,7 +366,7 @@ var _ = Describe("out", func() {
 
 				Expect(outResponse).To(Equal(out.OutResponse{
 					Version: gcsresource.Version{
-						Generation: int64(0),
+						Generation: "0",
 					},
 					Metadata: []gcsresource.MetadataPair{
 						{
@@ -422,7 +423,7 @@ var _ = Describe("out", func() {
 
 				Expect(outResponse).To(Equal(out.OutResponse{
 					Version: gcsresource.Version{
-						Generation: generations[0],
+						Generation: fmt.Sprintf("%d", generations[0]),
 					},
 					Metadata: []gcsresource.MetadataPair{
 						{

--- a/models.go
+++ b/models.go
@@ -1,5 +1,7 @@
 package gcsresource
 
+import "strconv"
+
 type Source struct {
 	JSONKey       string `json:"json_key"`
 	Bucket        string `json:"bucket"`
@@ -21,7 +23,15 @@ func (source Source) IsValid() (bool, string) {
 
 type Version struct {
 	Path       string `json:"path,omitempty"`
-	Generation int64  `json:"generation,omitempty"`
+	Generation string `json:"generation,omitempty"`
+}
+
+func (v Version) GenerationValue() (int64, error) {
+	i, err := strconv.ParseInt(v.Generation, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return i, nil
 }
 
 type MetadataPair struct {

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -47,7 +47,7 @@ func (command *OutCommand) Run(sourceDir string, request OutRequest) (OutRespons
 		version.Path = objectPath
 		url, _ = command.gcsClient.URL(bucketName, objectPath, 0)
 	} else {
-		version.Generation = generation
+		version.Generation = fmt.Sprintf("%d", generation)
 		url, _ = command.gcsClient.URL(bucketName, objectPath, generation)
 	}
 

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Out Command", func() {
 				Expect(generation).To(Equal(int64(0)))
 
 				Expect(response.Version.Path).To(Equal("folder/file.tgz"))
-				Expect(response.Version.Generation).To(Equal(int64(0)))
+				Expect(response.Version.Generation).To(Equal(""))
 
 				Expect(response.Metadata[0].Name).To(Equal("filename"))
 				Expect(response.Metadata[0].Value).To(Equal("file.tgz"))
@@ -239,7 +239,7 @@ var _ = Describe("Out Command", func() {
 				Expect(generation).To(Equal(int64(12345)))
 
 				Expect(response.Version.Path).To(BeEmpty())
-				Expect(response.Version.Generation).To(Equal(int64(12345)))
+				Expect(response.Version.Generation).To(Equal("12345"))
 
 				Expect(response.Metadata[0].Name).To(Equal("filename"))
 				Expect(response.Metadata[0].Value).To(Equal("version"))


### PR DESCRIPTION
- Concourse only allows strings in Version and Metadata output
- This is the quick-and-dirty fix by throwing `fmt.Sprintf` everywhere,
  let me know if there's a more clever way to do this

Fixes:
```
json: cannot unmarshal number into Go value of type string
```