### PR TITLE
Support unarchiving big tarballs

### DIFF
--- a/in/archive.go
+++ b/in/archive.go
@@ -173,12 +173,14 @@ func unpackTar(sourcePath, destinationDir string) error {
 		if err != nil {
 			return err
 		}
-		defer file.Close()
 
 		_, err = io.Copy(file, tarReader)
+		file.Close()
+		
 		if err != nil {
 			return err
 		}
+		
 	}
 
 	return nil


### PR DESCRIPTION
We were observing the following obscure error when unpacking tarballs with a large 
number of files:
```
error running command: failed to extract 'image.tgz' with the 'params.unpack' option enabled: open /tmp/build/get/rootfs/usr/lib/google-cloud-sdk/platform/gsutil/third_party/httplib2/python3/httplib2/socks.py: too many open files
```

We discovered that the failure was caused by the fact that the
`defer file.Close()` only runs when the function returns, so that
none of the files were closed.

We have copied the solution from the `unpackZip` function.