### PR TITLE
Removes -P flag from unzip command

### DIFF
--- a/in/archive.go
+++ b/in/archive.go
@@ -70,7 +70,7 @@ func unpack(mimeType, sourcePath string) error {
 }
 
 func unpackZip(sourcePath, destinationDir string) error {
-	cmd := exec.Command("unzip", "-P", "", "-d", destinationDir, sourcePath)
+	cmd := exec.Command("unzip", "-d", destinationDir, sourcePath)
 
 	return cmd.Run()
 }


### PR DESCRIPTION
The version of unzip in busybox image does not support the `-P` flag:

```
[ root@4a9869dba9ba:~ ]$ unzip -P "" -d /tmp/foo /root/in/helloworld-1.0.0.zip
unzip: invalid option -- 'P'
BusyBox v1.24.2 (2016-06-12 01:53:15 UTC) multi-call binary.

Usage: unzip [-lnopq] FILE[.zip] [FILE]... [-x FILE...] [-d DIR]

Extract FILEs from ZIP archive

	-l	List contents (with -q for short form)
	-n	Never overwrite files (default: ask)
	-o	Overwrite
	-p	Print to stdout
	-q	Quiet
	-x FILE	Exclude FILEs
	-d DIR	Extract into DIR
```

This commit removes the -P flag since the default decryption password is an empty string anyways.