### PR TITLE
Update base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM concourse/busyboxplus:git
+FROM alpine as certs
+RUN apk update && apk add ca-certificates
 
-# satisfy go crypto/x509
-RUN cat /etc/ssl/certs/*.pem > /etc/ssl/certs/ca-certificates.crt
+FROM busybox:1.30.1
+COPY --from=certs /etc/ssl/certs /etc/ssl/certs
 
 ADD assets/ /opt/resource/


### PR DESCRIPTION
In #24 I investigated odd IPv6 behaviour. While I did not get to the bottom of this, I could reproduce with `curl` in the container. After looking at the makeup of the container I realised it was based on [concourse/busyboxplus](https://hub.docker.com/r/concourse/busyboxplus) which hasn't been updated in 3 years. I wondered if updating to a more recent Busybox installation, known to be compatible with more recent Docker installations, might solve the issue. Particularly, Docker's v6 support 3 years ago wasn't what it is today.

This PR changes the Docker image to base on the official Busybox repo, at the latest version.

Unfortunately this Busybox installation doesn't come with CA certificates like the previously used installation, so we use a multipart Dockerfile to get a recent CA certificate bundle from Alpine, a very lightweight container with a package manager.

I couldn't figure out a nicer way to get recent certs from Busybox more directly, but am open to ideas. This solution felt much nicer than pulling in another unmaintained image with some old certs in. Theoretically the whole container could just be Alpine instead, but I thought that was too much of a change for this PR.

As far as I can tell, this upgrade fixes #24, however I'm unable to run all the tests myself.