### PR TITLE
Replacing old busybox image with Alpine (attempt #2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM concourse/busyboxplus:git
-
-# satisfy go crypto/x509
-RUN cat /etc/ssl/certs/*.pem > /etc/ssl/certs/ca-certificates.crt
+FROM alpine:edge
+RUN apk add --no-cache bash tzdata ca-certificates unzip zip gzip tar
 
 ADD assets/ /opt/resource/


### PR DESCRIPTION
Sending this pull request to resolve https://github.com/frodenas/gcs-resource/issues/24.

The original pull request (https://github.com/frodenas/gcs-resource/pull/25) is still open, but seems to have been dropped.

I updated the Dockerfile to use Alpine only, as well as pulling in the dependencies that the [s3 resource](https://github.com/concourse/s3-resource/) uses.  I've run the unit tests and integration tests with `make`, as well as building [my own version](https://hub.docker.com/r/adampiv/gcs-resource) of this docker image.  Using the alpine-based image, I'm no longer able to see the error.

@frodenas please let me know if there's a better way I should submit this, it didn't look like I had the option to change the original pull request.

(this is attempt 2, as the first PR failed CI tests because the branch had a slash in it)