### PR TITLE
Add skip_download get parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Places the following files in the destination:
 
 #### Parameters
 
+* `skip_download`: *Optional.* If true, skip downloading object from GCS.
+
+  This is useful to trigger a job that does not utilize the file, or to skip the implicit `get` after uploading a file to GCS using `put` (using `get_params`).
+
 * `unpack`: *Optional.* If true and the file is an archive (tar, gzipped tar, other gzipped file, or zip), unpack the file. Gzipped tarballs will be both ungzipped and untarred.
 
 ### `out`: Upload an object to the bucket.

--- a/in/in_command.go
+++ b/in/in_command.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/frodenas/gcs-resource"
+	gcsresource "github.com/frodenas/gcs-resource"
 	"github.com/frodenas/gcs-resource/versions"
 )
 
@@ -51,15 +51,17 @@ func (command *InCommand) inByRegex(destinationDir string, request InRequest) (I
 		return InResponse{}, err
 	}
 
-	localPath := filepath.Join(destinationDir, filepath.Base(objectPath))
+	if !request.Params.SkipDownload {
+		localPath := filepath.Join(destinationDir, filepath.Base(objectPath))
 
-	if err := command.downloadFile(bucketName, objectPath, 0, localPath); err != nil {
-		return InResponse{}, err
-	}
-
-	if request.Params.Unpack {
-		if err := command.unpackFile(localPath); err != nil {
+		if err := command.downloadFile(bucketName, objectPath, 0, localPath); err != nil {
 			return InResponse{}, err
+		}
+
+		if request.Params.Unpack {
+			if err := command.unpackFile(localPath); err != nil {
+				return InResponse{}, err
+			}
 		}
 	}
 
@@ -111,15 +113,17 @@ func (command *InCommand) inByVersionedFile(destinationDir string, request InReq
 		return InResponse{}, err
 	}
 
-	localPath := filepath.Join(destinationDir, filepath.Base(objectPath))
+	if !request.Params.SkipDownload {
+		localPath := filepath.Join(destinationDir, filepath.Base(objectPath))
 
-	if err := command.downloadFile(bucketName, objectPath, generation, localPath); err != nil {
-		return InResponse{}, err
-	}
-
-	if request.Params.Unpack {
-		if err := command.unpackFile(localPath); err != nil {
+		if err := command.downloadFile(bucketName, objectPath, generation, localPath); err != nil {
 			return InResponse{}, err
+		}
+
+		if request.Params.Unpack {
+			if err := command.unpackFile(localPath); err != nil {
+				return InResponse{}, err
+			}
 		}
 	}
 

--- a/in/in_command_test.go
+++ b/in/in_command_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/frodenas/gcs-resource"
+	gcsresource "github.com/frodenas/gcs-resource"
 	"github.com/frodenas/gcs-resource/fakes"
 
 	. "github.com/frodenas/gcs-resource/in"
@@ -317,6 +317,19 @@ var _ = Describe("In Command", func() {
 					Expect(err.Error()).To(ContainSubstring("error url"))
 				})
 
+				Describe("when 'skip_download' is specified", func() {
+					BeforeEach(func() {
+						request.Params.SkipDownload = true
+					})
+
+					It("skips the download of the file", func() {
+						_, err := command.Run(destDir, request)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(gcsClient.DownloadFileCallCount()).To(Equal(0))
+					})
+				})
+
 				Describe("when 'unpack' is specified", func() {
 					BeforeEach(func() {
 						request.Params.Unpack = true
@@ -499,6 +512,19 @@ var _ = Describe("In Command", func() {
 				_, err := command.Run(destDir, request)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("error url"))
+			})
+
+			Describe("when 'skip_download' is specified", func() {
+				BeforeEach(func() {
+					request.Params.SkipDownload = true
+				})
+
+				It("skips the download of the file", func() {
+					_, err := command.Run(destDir, request)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(gcsClient.DownloadFileCallCount()).To(Equal(0))
+				})
 			})
 
 			Describe("when 'unpack' is specified", func() {

--- a/in/models.go
+++ b/in/models.go
@@ -11,8 +11,8 @@ type InRequest struct {
 }
 
 type Params struct {
-	SkipDownload bool `json:"skip_download"`
-	Unpack       bool `json:"unpack"`
+	SkipDownload string `json:"skip_download"`
+	Unpack       bool   `json:"unpack"`
 }
 
 type InResponse struct {

--- a/in/models.go
+++ b/in/models.go
@@ -1,7 +1,7 @@
 package in
 
 import (
-	"github.com/frodenas/gcs-resource"
+	gcsresource "github.com/frodenas/gcs-resource"
 )
 
 type InRequest struct {
@@ -11,7 +11,8 @@ type InRequest struct {
 }
 
 type Params struct {
-	Unpack bool `json:"unpack"`
+	SkipDownload bool `json:"skip_download"`
+	Unpack       bool `json:"unpack"`
 }
 
 type InResponse struct {

--- a/integration/in_test.go
+++ b/integration/in_test.go
@@ -208,7 +208,7 @@ var _ = Describe("in", func() {
 				})
 			})
 
-			Context("when path exists and 'skip_download' is specified", func() {
+			Context("when path exists and 'skip_download' is specified as a source param", func() {
 				BeforeEach(func() {
 					tempDir, err := ioutil.TempDir("", directoryPrefix)
 					Expect(err).ToNot(HaveOccurred())
@@ -232,15 +232,13 @@ var _ = Describe("in", func() {
 
 					inRequest = in.InRequest{
 						Source: gcsresource.Source{
-							JSONKey: jsonKey,
-							Bucket:  bucketName,
-							Regexp:  filepath.Join(directoryPrefix, "file-to-download-(.*)"),
+							JSONKey:      jsonKey,
+							Bucket:       bucketName,
+							Regexp:       filepath.Join(directoryPrefix, "file-to-download-(.*)"),
+							SkipDownload: true,
 						},
 						Version: gcsresource.Version{
 							Path: filepath.Join(directoryPrefix, "file-to-download.tgz"),
-						},
-						Params: in.Params{
-							SkipDownload: true,
 						},
 					}
 
@@ -581,7 +579,7 @@ var _ = Describe("in", func() {
 				})
 			})
 
-			Context("when the versioned file exists and 'skip_download' is specified", func() {
+			Context("when the versioned file exists and 'skip_download' is specified as a get param", func() {
 				var (
 					generation int64
 				)
@@ -617,7 +615,7 @@ var _ = Describe("in", func() {
 							Generation: fmt.Sprintf("%d", generation),
 						},
 						Params: in.Params{
-							SkipDownload: true,
+							SkipDownload: "true",
 						},
 					}
 

--- a/integration/in_test.go
+++ b/integration/in_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 
-	"github.com/frodenas/gcs-resource"
+	gcsresource "github.com/frodenas/gcs-resource"
 	"github.com/frodenas/gcs-resource/in"
-	"github.com/nu7hatch/gouuid"
+	uuid "github.com/nu7hatch/gouuid"
 )
 
 var _ = Describe("in", func() {
@@ -200,6 +200,84 @@ var _ = Describe("in", func() {
 					versionContents, err := ioutil.ReadFile(filepath.Join(destDir, "version"))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(versionContents).To(Equal([]byte("1")))
+
+					Expect(filepath.Join(destDir, "url")).To(BeARegularFile())
+					urlContents, err := ioutil.ReadFile(filepath.Join(destDir, "url"))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(urlContents).To(Equal([]byte(url)))
+				})
+			})
+
+			Context("when path exists and 'skip_download' is specified", func() {
+				BeforeEach(func() {
+					tempDir, err := ioutil.TempDir("", directoryPrefix)
+					Expect(err).ToNot(HaveOccurred())
+
+					tempFilePath := filepath.Join(tempDir, "file-to-download.txt")
+					tempTarballPath := filepath.Join(tempDir, "file-to-download.tgz")
+
+					err = ioutil.WriteFile(tempFilePath, []byte("file-to-download-4"), 0600)
+					Expect(err).ToNot(HaveOccurred())
+
+					command := exec.Command("tar", "czf", tempTarballPath, "-C", tempDir, "file-to-download.txt")
+					session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(session).Should(gexec.Exit(0))
+
+					_, err = gcsClient.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-to-download.tgz"), "", tempTarballPath, "", "")
+					Expect(err).ToNot(HaveOccurred())
+
+					err = os.RemoveAll(tempDir)
+					Expect(err).NotTo(HaveOccurred())
+
+					inRequest = in.InRequest{
+						Source: gcsresource.Source{
+							JSONKey: jsonKey,
+							Bucket:  bucketName,
+							Regexp:  filepath.Join(directoryPrefix, "file-to-download-(.*)"),
+						},
+						Version: gcsresource.Version{
+							Path: filepath.Join(directoryPrefix, "file-to-download.tgz"),
+						},
+						Params: in.Params{
+							SkipDownload: true,
+						},
+					}
+
+					err = json.NewEncoder(stdin).Encode(inRequest)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				AfterEach(func() {
+					err = gcsClient.DeleteObject(bucketName, filepath.Join(directoryPrefix, "file-to-download.tgz"), 0)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("skips the download of the file, but still outputs the response", func() {
+					reader := bytes.NewBuffer(session.Out.Contents())
+					err = json.NewDecoder(reader).Decode(&inResponse)
+					Expect(err).ToNot(HaveOccurred())
+
+					url, err := gcsClient.URL(bucketName, filepath.Join(directoryPrefix, "file-to-download.tgz"), int64(0))
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(inResponse).To(Equal(in.InResponse{
+						Version: gcsresource.Version{
+							Path: filepath.Join(directoryPrefix, "file-to-download.tgz"),
+						},
+						Metadata: []gcsresource.MetadataPair{
+							{
+								Name:  "filename",
+								Value: "file-to-download.tgz",
+							},
+							{
+								Name:  "url",
+								Value: url,
+							},
+						},
+					}))
+
+					Expect(filepath.Join(destDir, "file-to-download.tgz")).NotTo(BeARegularFile())
 
 					Expect(filepath.Join(destDir, "url")).To(BeARegularFile())
 					urlContents, err := ioutil.ReadFile(filepath.Join(destDir, "url"))
@@ -495,6 +573,93 @@ var _ = Describe("in", func() {
 					versionContents, err := ioutil.ReadFile(filepath.Join(destDir, "generation"))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(versionContents).To(Equal([]byte(strconv.FormatInt(generation2, 10))))
+
+					Expect(filepath.Join(destDir, "url")).To(BeARegularFile())
+					urlContents, err := ioutil.ReadFile(filepath.Join(destDir, "url"))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(urlContents).To(Equal([]byte(url)))
+				})
+			})
+
+			Context("when the versioned file exists and 'skip_download' is specified", func() {
+				var (
+					generation int64
+				)
+
+				BeforeEach(func() {
+					tempDir, err := ioutil.TempDir("", directoryPrefix)
+					Expect(err).ToNot(HaveOccurred())
+
+					tempFilePath := filepath.Join(tempDir, "version.txt")
+					tempTarballPath := filepath.Join(tempDir, "version.tgz")
+
+					err = ioutil.WriteFile(tempFilePath, []byte("generation-4"), 0600)
+					Expect(err).ToNot(HaveOccurred())
+
+					command := exec.Command("tar", "czf", tempTarballPath, "-C", tempDir, "version.txt")
+					session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(session).Should(gexec.Exit(0))
+
+					generation, err = gcsClient.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "version.tgz"), "", tempTarballPath, "", "")
+					Expect(err).ToNot(HaveOccurred())
+
+					err = os.RemoveAll(tempDir)
+					Expect(err).NotTo(HaveOccurred())
+
+					inRequest = in.InRequest{
+						Source: gcsresource.Source{
+							JSONKey:       jsonKey,
+							Bucket:        versionedBucketName,
+							VersionedFile: filepath.Join(directoryPrefix, "version.tgz"),
+						},
+						Version: gcsresource.Version{
+							Generation: fmt.Sprintf("%d", generation),
+						},
+						Params: in.Params{
+							SkipDownload: true,
+						},
+					}
+
+					err = json.NewEncoder(stdin).Encode(inRequest)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				AfterEach(func() {
+					err := gcsClient.DeleteObject(versionedBucketName, filepath.Join(directoryPrefix, "version.tgz"), generation)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("skips the download of the file, but still outputs the response", func() {
+					reader := bytes.NewBuffer(session.Out.Contents())
+					err = json.NewDecoder(reader).Decode(&inResponse)
+					Expect(err).ToNot(HaveOccurred())
+
+					url, err := gcsClient.URL(versionedBucketName, filepath.Join(directoryPrefix, "version.tgz"), generation)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(inResponse).To(Equal(in.InResponse{
+						Version: gcsresource.Version{
+							Generation: fmt.Sprintf("%d", generation),
+						},
+						Metadata: []gcsresource.MetadataPair{
+							{
+								Name:  "filename",
+								Value: "version.tgz",
+							},
+							{
+								Name:  "url",
+								Value: url,
+							},
+						},
+					}))
+
+					Expect(filepath.Join(destDir, "version.txt")).NotTo(BeARegularFile())
+
+					Expect(filepath.Join(destDir, "generation")).To(BeARegularFile())
+					versionContents, err := ioutil.ReadFile(filepath.Join(destDir, "generation"))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(versionContents).To(Equal([]byte(strconv.FormatInt(generation, 10))))
 
 					Expect(filepath.Join(destDir, "url")).To(BeARegularFile())
 					urlContents, err := ioutil.ReadFile(filepath.Join(destDir, "url"))

--- a/models.go
+++ b/models.go
@@ -7,6 +7,7 @@ type Source struct {
 	Bucket        string `json:"bucket"`
 	Regexp        string `json:"regexp"`
 	VersionedFile string `json:"versioned_file"`
+	SkipDownload  bool   `json:"skip_download"`
 }
 
 func (source Source) IsValid() (bool, string) {


### PR DESCRIPTION
This PR adds the ability to skip downloading the file on a get. Useful for skipping the implicit get after a put, or for triggering a job that doesn't actually use the file.

Regards,
Dave